### PR TITLE
[training#1] add catalog ls task into node discovery graph

### DIFF
--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -90,6 +90,14 @@ module.exports = {
             ignoreFailure: true
         },
         {
+            label: 'catalog-ls',
+            taskName: 'Task.Catalog.ls',
+            waitOn: {
+                'catalog-lldp': 'finished'
+            },
+            ignoreFailure: true
+        },
+        {
             "label": "set-boot-pxe",
             "taskDefinition": {
                 "friendlyName": "Set PXE boot",
@@ -101,7 +109,7 @@ module.exports = {
                 "properties": {}
             },
             waitOn: {
-               'catalog-lldp': 'finished'
+               'catalog-ls': 'finished'
             }
         },
         {


### PR DESCRIPTION
## Background
Training#1: Design a Linux catalog task which parse the ls -l /var and store the result into source ls.

## Related PR:
https://github.com/iceiilin/on-tasks/pull/2

## Implementation:
add catalog ls task into node discovery graph

## Result:
please refer to the related PR above